### PR TITLE
UITextField Placeholder Support

### DIFF
--- a/Source/UIKit+Theme.swift
+++ b/Source/UIKit+Theme.swift
@@ -121,6 +121,10 @@ import UIKit
         get { return getThemePicker(self, "setTextColor:") as? ThemeColorPicker }
         set { setThemePicker(self, "setTextColor:", newValue) }
     }
+    var theme_placeholderAttributes: ThemeDictionaryPicker? {
+        get { return getThemePicker(self, "updatePlaceholderAttributes:") as? ThemeDictionaryPicker }
+        set { setThemePicker(self, "updatePlaceholderAttributes:", newValue) }
+    }
 }
 @objc public extension UITextView
 {

--- a/Source/UITextField+PlaceholderAttributes.swift
+++ b/Source/UITextField+PlaceholderAttributes.swift
@@ -1,0 +1,33 @@
+//
+//  UITextField+PlaceholderAttributes.swift
+//  SwiftTheme
+//
+//  Created by kcramer on 3/6/18.
+//  Copyright © 2018. All rights reserved.
+//
+
+import UIKit
+
+extension UITextField {
+    @objc func updatePlaceholderAttributes(_ newAttributes: [NSAttributedStringKey: Any]) {
+        guard let placeholder = self.attributedPlaceholder else { return }
+        let newString = NSMutableAttributedString(attributedString: placeholder)
+        let range = NSMakeRange(0, placeholder.length)
+        newString.enumerateAttributes(in: range, options: []) { (currentAttributes, range, _) in
+            let mergedAttributes = currentAttributes.merge(with: newAttributes)
+            newString.setAttributes(mergedAttributes, range: range)
+        }
+        self.attributedPlaceholder = newString
+    }
+}
+
+// Merge a dictionary into another dictionary, returning a new dictionary.
+// The values of the other dictionary overwrite the values of the current dictionary.
+private extension Dictionary {
+    func merge(with dict: Dictionary) -> Dictionary {
+        return dict.reduce(into: self) { (result, pair) in
+            let (key, value) = pair
+            result[key] = value
+        }
+    }
+}

--- a/SwiftTheme.xcodeproj/project.pbxproj
+++ b/SwiftTheme.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0AD183E6204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD183E5204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift */; };
+		0AD183E7204FA166005F5D85 /* UITextField+PlaceholderAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD183E5204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift */; };
 		1854EB631C96601E00E865C6 /* AboutCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1854EB5D1C96601E00E865C6 /* AboutCell.swift */; };
 		1854EB641C96601E00E865C6 /* ChangeThemeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1854EB5E1C96601E00E865C6 /* ChangeThemeCell.swift */; };
 		1854EB651C96601E00E865C6 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1854EB5F1C96601E00E865C6 /* ListViewController.swift */; };
@@ -183,6 +185,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0AD183E5204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+PlaceholderAttributes.swift"; sourceTree = "<group>"; };
 		1854EB5D1C96601E00E865C6 /* AboutCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutCell.swift; sourceTree = "<group>"; };
 		1854EB5E1C96601E00E865C6 /* ChangeThemeCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangeThemeCell.swift; sourceTree = "<group>"; };
 		1854EB5F1C96601E00E865C6 /* ListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
@@ -480,6 +483,7 @@
 				18D642E11C53638200DADEC5 /* UIColorExtension.swift */,
 				18D642E21C53638200DADEC5 /* UIKit+Theme.swift */,
 				18D642E31C53638200DADEC5 /* NSObject+Theme.swift */,
+				0AD183E5204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -943,6 +947,7 @@
 				18D642E81C53638200DADEC5 /* UIKit+Theme.swift in Sources */,
 				A373E39A1E3C34C600ED2F2B /* ThemeStatusBarStylePicker.swift in Sources */,
 				A3A389991D8E2F2800797F17 /* ThemeManager+OC.swift in Sources */,
+				0AD183E6204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift in Sources */,
 				A373E3811E3C341200ED2F2B /* ThemeColorPicker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1013,6 +1018,7 @@
 				A37F8C931F8A43B300ABB5EC /* UIColorExtension.swift in Sources */,
 				A37F8C941F8A43B300ABB5EC /* UIKit+Theme.swift in Sources */,
 				A37F8C951F8A43B300ABB5EC /* NSObject+Theme.swift in Sources */,
+				0AD183E7204FA166005F5D85 /* UITextField+PlaceholderAttributes.swift in Sources */,
 				A37F8C991F8A556600ABB5EC /* ThemeBarStylePicker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This pull request adds theme support for the placeholder text of a UITextField.  It merges the dictionary of attributes defined for the current theme into the existing attributes of the UITextField's attributedPlaceholder.  Attributes from the theme overwrite the attributes of the attributedPlaceholder.

Merging preserves the other default attributes.  Most developers will only want to change the text color or possibly the font.  NSMutableAttributedString.enumerateAttributes is used in case multiple ranges of attributes were defined.