### PR TITLE
UIRefreshControl attributedTitle Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ NotificationCenter.default.addObserver(
 - var theme_font: ThemeFontPicker?
 - var theme_keyboardAppearance: ThemeKeyboardAppearancePicker?
 - var theme_textColor: ThemeColorPicker?
+- var theme_placeholderAttributes: ThemeDictionaryPicker?
 
 ##### UITextView
 - var theme_font: ThemeFontPicker?
@@ -303,6 +304,9 @@ NotificationCenter.default.addObserver(
 - var theme_borderWidth: ThemeCGFloatPicker?
 - var theme_borderColor: ThemeCGColorPicker?
 - var theme_shadowColor: ThemeCGColorPicker?
+
+##### UIRefreshControl
+- var theme_titleAttributes: ThemeDictionaryPicker?
 
 ### *Picker*
 ***

--- a/Source/NSAttributedString+Merge.swift
+++ b/Source/NSAttributedString+Merge.swift
@@ -1,0 +1,39 @@
+//
+//  NSAttributedString+Merge.swift
+//  SwiftTheme
+//
+//  Created by kcramer on 3/31/18.
+//  Copyright © 2018 kcramer. All rights reserved.
+//
+
+import Foundation
+
+extension NSAttributedString {
+    // Initialize a new attributed string from an existing attributed string,
+    // merging the specified attributes.
+    // The specified attributes overwrite existing attributes with the
+    /// same keys. All other attributes are preserved.
+    convenience init(attributedString attrStr: NSAttributedString,
+                     merging newAttributes: [NSAttributedStringKey: Any]) {
+        let newString = NSMutableAttributedString(attributedString: attrStr)
+        let range = NSMakeRange(0, attrStr.length)
+        newString.enumerateAttributes(in: range, options: []) {
+            (currentAttributes, range, _) in
+            let mergedAttributes = currentAttributes.merge(with: newAttributes)
+            newString.setAttributes(mergedAttributes, range: range)
+        }
+        self.init(attributedString: newString)
+    }
+}
+
+// Merge a dictionary into another dictionary, returning a new dictionary.
+// The values of the other dictionary overwrite the values of the current
+// dictionary.
+private extension Dictionary {
+    func merge(with dict: Dictionary) -> Dictionary {
+        return dict.reduce(into: self) { (result, pair) in
+            let (key, value) = pair
+            result[key] = value
+        }
+    }
+}

--- a/Source/UIKit+Theme.swift
+++ b/Source/UIKit+Theme.swift
@@ -282,6 +282,13 @@ import UIKit
         set { setThemePicker(self, "setBackgroundColor:", newValue) }
     }
 }
+@objc public extension UIRefreshControl
+{
+    var theme_titleAttributes: ThemeDictionaryPicker? {
+        get { return getThemePicker(self, "updateTitleAttributes:") as? ThemeDictionaryPicker }
+        set { setThemePicker(self, "updateTitleAttributes:", newValue) }
+    }
+}
 #endif
 
 private func getThemePicker(

--- a/Source/UIRefreshControl+TitleAttributes.swift
+++ b/Source/UIRefreshControl+TitleAttributes.swift
@@ -1,0 +1,18 @@
+//
+//  UIRefreshControl+TitleAttributes.swift
+//  SwiftTheme
+//
+//  Created by kcramer on 4/1/18.
+//  Copyright © 2018 Gesen. All rights reserved.
+//
+
+import Foundation
+
+extension UIRefreshControl {
+    @objc func updateTitleAttributes(_ newAttributes: [NSAttributedStringKey: Any]) {
+        guard let title = self.attributedTitle else { return }
+        let newString = NSAttributedString(attributedString: title,
+                                           merging: newAttributes)
+        self.attributedTitle = newString
+    }
+}

--- a/Source/UITextField+PlaceholderAttributes.swift
+++ b/Source/UITextField+PlaceholderAttributes.swift
@@ -11,23 +11,8 @@ import UIKit
 extension UITextField {
     @objc func updatePlaceholderAttributes(_ newAttributes: [NSAttributedStringKey: Any]) {
         guard let placeholder = self.attributedPlaceholder else { return }
-        let newString = NSMutableAttributedString(attributedString: placeholder)
-        let range = NSMakeRange(0, placeholder.length)
-        newString.enumerateAttributes(in: range, options: []) { (currentAttributes, range, _) in
-            let mergedAttributes = currentAttributes.merge(with: newAttributes)
-            newString.setAttributes(mergedAttributes, range: range)
-        }
+        let newString = NSAttributedString(attributedString: placeholder,
+                                           merging: newAttributes)
         self.attributedPlaceholder = newString
-    }
-}
-
-// Merge a dictionary into another dictionary, returning a new dictionary.
-// The values of the other dictionary overwrite the values of the current dictionary.
-private extension Dictionary {
-    func merge(with dict: Dictionary) -> Dictionary {
-        return dict.reduce(into: self) { (result, pair) in
-            let (key, value) = pair
-            result[key] = value
-        }
     }
 }

--- a/SwiftTheme.xcodeproj/project.pbxproj
+++ b/SwiftTheme.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A2210CB207090BF006BC28D /* NSAttributedString+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2210CA207090BF006BC28D /* NSAttributedString+Merge.swift */; };
+		0A2210CD207095F6006BC28D /* UIRefreshControl+TitleAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2210CC207095F6006BC28D /* UIRefreshControl+TitleAttributes.swift */; };
 		0AD183E6204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD183E5204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift */; };
 		0AD183E7204FA166005F5D85 /* UITextField+PlaceholderAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD183E5204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift */; };
 		1854EB631C96601E00E865C6 /* AboutCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1854EB5D1C96601E00E865C6 /* AboutCell.swift */; };
@@ -185,6 +187,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0A2210CA207090BF006BC28D /* NSAttributedString+Merge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Merge.swift"; sourceTree = "<group>"; };
+		0A2210CC207095F6006BC28D /* UIRefreshControl+TitleAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+TitleAttributes.swift"; sourceTree = "<group>"; };
 		0AD183E5204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+PlaceholderAttributes.swift"; sourceTree = "<group>"; };
 		1854EB5D1C96601E00E865C6 /* AboutCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutCell.swift; sourceTree = "<group>"; };
 		1854EB5E1C96601E00E865C6 /* ChangeThemeCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangeThemeCell.swift; sourceTree = "<group>"; };
@@ -483,7 +487,9 @@
 				18D642E11C53638200DADEC5 /* UIColorExtension.swift */,
 				18D642E21C53638200DADEC5 /* UIKit+Theme.swift */,
 				18D642E31C53638200DADEC5 /* NSObject+Theme.swift */,
+				0A2210CA207090BF006BC28D /* NSAttributedString+Merge.swift */,
 				0AD183E5204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift */,
+				0A2210CC207095F6006BC28D /* UIRefreshControl+TitleAttributes.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -930,6 +936,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A3D5F8191E3C56CD00F901C1 /* ThemeActivityIndicatorViewStylePicker.swift in Sources */,
+				0A2210CD207095F6006BC28D /* UIRefreshControl+TitleAttributes.swift in Sources */,
 				A3A3899D1D8E2FB200797F17 /* ThemeManager+Plist.swift in Sources */,
 				A373E3901E3C348B00ED2F2B /* ThemeCGColorPicker.swift in Sources */,
 				18D642EA1C53638200DADEC5 /* NSObject+Theme.swift in Sources */,
@@ -946,6 +953,7 @@
 				A3D5F8141E3C4D3900F901C1 /* ThemeBarStylePicker.swift in Sources */,
 				18D642E81C53638200DADEC5 /* UIKit+Theme.swift in Sources */,
 				A373E39A1E3C34C600ED2F2B /* ThemeStatusBarStylePicker.swift in Sources */,
+				0A2210CB207090BF006BC28D /* NSAttributedString+Merge.swift in Sources */,
 				A3A389991D8E2F2800797F17 /* ThemeManager+OC.swift in Sources */,
 				0AD183E6204F8B90005F5D85 /* UITextField+PlaceholderAttributes.swift in Sources */,
 				A373E3811E3C341200ED2F2B /* ThemeColorPicker.swift in Sources */,


### PR DESCRIPTION
This pull request builds on my previous one and adds theme support for UIRefreshControl's attributedTitle field.  Like UITextField's placeholder, UIRefreshControl only provides an NSAttributedString for the content and styling.

The code used to merge dictionaries was moved into a new NSAttributedString initializer for re-use.  The previous change for UITextField was updated to use this new function.

Finally, I updated the README.md to include the two new theme options in the Supported Properties list.