### PR TITLE
Drops usage of `displayP3Red:` init in hex UIColor init; fixes #68

### DIFF
--- a/Source/UIColorExtension.swift
+++ b/Source/UIColorExtension.swift
@@ -32,12 +32,8 @@ public enum UIColorInputError : Error {
         let red     = CGFloat((hex3 & 0xF00) >> 8) / divisor
         let green   = CGFloat((hex3 & 0x0F0) >> 4) / divisor
         let blue    = CGFloat( hex3 & 0x00F      ) / divisor
-        
-        if #available(iOS 10.0, tvOS 10.0, *) {
-            self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
-        } else {
-            self.init(red: red, green: green, blue: blue, alpha: alpha)
-        }
+
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
     
     /**
@@ -52,12 +48,8 @@ public enum UIColorInputError : Error {
         let green   = CGFloat((hex4 & 0x0F00) >>  8) / divisor
         let blue    = CGFloat((hex4 & 0x00F0) >>  4) / divisor
         let alpha   = CGFloat( hex4 & 0x000F       ) / divisor
-        
-        if #available(iOS 10.0, tvOS 10.0, *) {
-            self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
-        } else {
-            self.init(red: red, green: green, blue: blue, alpha: alpha)
-        }
+
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
     
     /**
@@ -70,12 +62,8 @@ public enum UIColorInputError : Error {
         let red     = CGFloat((hex6 & 0xFF0000) >> 16) / divisor
         let green   = CGFloat((hex6 & 0x00FF00) >>  8) / divisor
         let blue    = CGFloat( hex6 & 0x0000FF       ) / divisor
-        
-        if #available(iOS 10.0, tvOS 10.0, *) {
-            self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
-        } else {
-            self.init(red: red, green: green, blue: blue, alpha: alpha)
-        }
+
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
     
     /**
@@ -89,12 +77,8 @@ public enum UIColorInputError : Error {
         let green   = CGFloat((hex8 & 0x00FF0000) >> 16) / divisor
         let blue    = CGFloat((hex8 & 0x0000FF00) >>  8) / divisor
         let alpha   = CGFloat( hex8 & 0x000000FF       ) / divisor
-        
-        if #available(iOS 10.0, tvOS 10.0, *) {
-            self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
-        } else {
-            self.init(red: red, green: green, blue: blue, alpha: alpha)
-        }
+
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
     
     /**


### PR DESCRIPTION
Fixes #68 

Using UIColor's `init(displayP3Red:green:blue:alpha:)` initializer when creating a color produces unexpected behavior. At best, creating a color this way, then calling `hexString(:)` returns a valid hex string that *does not match* the hex string used to initialize the color. At worst, it returns *an invalid hex string* that cannot be used to create a new instance of UIColor.

**Example 1**: Output hex doesn't match the input hex
```swift
print(UIColor(rgba: "#EFEFEF").hexString(false))
// Output = #EEEFEE
```

**Example 2**: Output hex is invalid
```swift
print(UIColor(rgba: "#DC0064").hexString(false))
// Output = #F0FFFFFFD063
```

A stack overflow post discussing the issue/misuse of this initializer: https://stackoverflow.com/questions/49039235/best-practices-when-initializing-a-uicolor-displayp3-color

This PR removes the usages of `UIColor(displayP3Red:green:blue:alpha:)`, so creating a color with a hex string now produces a color whose `hexString(:)` func returns the same hex string it was created with.